### PR TITLE
Is this extension supported?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # vscode-alex
-
+ 
 [![Dependency Status](https://david-dm.org/tlahmann/vscode-alex.svg)](https://david-dm.org/tlahmann/vscode-alex)
 [![devDependency Status](https://david-dm.org/tlahmann/vscode-alex/dev-status.svg)](https://david-dm.org/tlahmann/vscode-alex?type=dev)
 


### PR DESCRIPTION
Hey,

Tried using the extension, but it seems there are issues with it loading in Visual Studio Code. It seems to be unable to load `vscode-languageclient`.

Are you still supporting this extension?

You don't have issues enabled (as this is a fork), so I created this PR to reach out to you.