### PR TITLE
feat: support (Neo)Vim by coc.nvim

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,12 +1,22 @@
 import * as path from 'path';
+//# #if HAVE_VSCODE
 import { workspace, ExtensionContext } from 'vscode';
 import * as vscode from 'vscode';
+//# #elif HAVE_COC_NVIM
+//# import { workspace, ExtensionContext } from 'coc.nvim';
+//# import * as vscode from 'coc.nvim';
+//# #endif
 import {
     LanguageClient,
     LanguageClientOptions,
     ServerOptions,
-    TransportKind
+    TransportKind,
+//# #if HAVE_VSCODE
 } from 'vscode-languageclient/node';
+//# #elif HAVE_COC_NVIM
+//# services,
+//# } from 'coc.nvim';
+//# #endif
 
 const DIAGNOSTICS_COLLECTION_NAME = 'AlexLinter';
 let diagnosticsCollection: vscode.DiagnosticCollection;
@@ -22,7 +32,11 @@ export function activate(context: ExtensionContext) {
     ///////////////////////////////////////////////
 
     // The server is implemented in node
+    //# #if HAVE_VSCODE
     const serverModule = context.asAbsolutePath(path.join('server', 'out', 'server.js'));
+    //# #elif HAVE_COC_NVIM
+    //# const serverModule = path.join(__dirname, 'server.js');
+    //# #endif
     // If the extension is launched in debug mode then the debug server options are used
     // Otherwise the run options are used
     const serverOptions: ServerOptions = {
@@ -41,7 +55,11 @@ export function activate(context: ExtensionContext) {
         // Register the server for plain text, markdown and latex documents
         documentSelector: [
             { scheme: 'file', language: 'plaintext' },
+            { scheme: 'file', language: 'gitcommit' },
+            { scheme: 'file', language: 'bbcode' },
             { scheme: 'file', language: 'markdown' },
+            { scheme: 'file', language: 'mdx' },
+            { scheme: 'file', language: 'html' },
             { scheme: 'file', language: 'latex' }
         ],
         diagnosticCollectionName: DIAGNOSTICS_COLLECTION_NAME,
@@ -61,11 +79,17 @@ export function activate(context: ExtensionContext) {
 
     // Start the client. This will also launch the server
     context.subscriptions.push(
+        //# #if HAVE_VSCODE
         client.start(),
+        //# #elif HAVE_COC_NVIM
+        //# services.registerLanguageClient(client)
+        //# #endif
     );
 }
 
 // Stop client when extension is deactivated
+//# #if HAVE_VSCODE
 export function deactivate(): Thenable<void> {
     return client.stop();
 }
+//# #endif

--- a/client/src/server.ts
+++ b/client/src/server.ts
@@ -1,0 +1,1 @@
+import 'alex-server/out/server'

--- a/coc-alex/.npmignore
+++ b/coc-alex/.npmignore
@@ -1,0 +1,8 @@
+/*
+!/out/
+*.map
+*.LICENSE.txt
+!/prebuilds/
+!/binding.gyp
+!/binding.c
+!/flake.nix

--- a/coc-alex/README.md
+++ b/coc-alex/README.md
@@ -1,0 +1,20 @@
+# coc-alex
+
+Ported from [vscode-alex](https://github.com/tlahmann/vscode-alex).
+
+## Install
+
+- [coc-marketplace](https://github.com/fannheyward/coc-marketplace)
+- [npm](https://www.npmjs.com/package/coc-alex)
+- vim:
+
+```vim
+" command line
+CocInstall coc-alex
+" or add the following code to your vimrc
+let g:coc_global_extensions = ['coc-alex', 'other coc-plugins']
+```
+
+## Usage
+
+Refer [vscode-alex](https://github.com/tlahmann/vscode-alex).

--- a/coc-alex/package.json
+++ b/coc-alex/package.json
@@ -1,36 +1,32 @@
 {
-    "name": "alex-linter",
-    "version": "0.6.6",
-    "displayName": "AlexJS Linter",
+    "name": "coc-alex",
+    "version": "0.0.4",
     "description": "Find gender favouring, race related, religion inconsiderate or other unequal phrasing",
-    "publisher": "tlahmann",
-    "contributors": [
-        {
-            "name": "shinnn",
-            "url": "https://github.com/shinnn/"
-        }
-    ],
-    "icon": "media/icon.png",
     "repository": "https://github.com/tlahmann/vscode-alex",
     "homepage": "https://github.com/tlahmann/vscode-alex#readme",
     "bugs": "https://github.com/tlahmann/vscode-alex/issues",
     "license": "MIT",
-    "galleryBanner": {
-        "color": "#FAFAFA",
-        "theme": "light"
-    },
     "engines": {
-        "vscode": "^1.47.0"
+        "coc": "^0.0.80"
     },
+    "keywords": [
+        "coc.nvim"
+    ],
+    "main": "out/extension.js",
     "activationEvents": [
         "onLanguage:plaintext",
+        "onLanguage:gitcommit",
+        "onLanguage:bbcode",
+        "onLanguage:markdown",
+        "onLanguage:mdx",
+        "onLanguage:html",
+        "onLanguage:latex",
         "onCommand:alex-linter.lint"
     ],
-    "categories": [
-        "Linters",
-        "Other"
-    ],
-    "main": "./client/out/extension",
+    "scripts": {
+        "patch": "scripts/patch.sh ../client/src/*.ts",
+        "prepack": "npm run patch && webpack-cli --mode production --config webpack.config.js"
+    },
     "contributes": {
         "configuration": {
             "type": "object",
@@ -80,27 +76,19 @@
             }
         ]
     },
-    "scripts": {
-        "compile": "tsc -b",
-        "webpack": "npm run clean && webpack --mode production --config ./client/webpack.config.js && webpack --mode production --config ./server/webpack.config.js",
-        "webpack:dev": "npm run clean && webpack --mode none --config ./client/webpack.config.js && webpack --mode none --config ./server/webpack.config.js",
-        "watch": "tsc -b -w",
-        "lint": "eslint ./client/src ./server/src --ext .ts,.tsx",
-        "postinstall": "cd server && npm install && cd ../client && npm install && cd ..",
-        "clean": "rimraf client/out && rimraf server/out",
-        "test": "sh ./scripts/e2e.sh"
-    },
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "@typescript-eslint/eslint-plugin": "^4.31.2",
         "@typescript-eslint/parser": "^4.31.2",
+        "alex-server": "^0.0.3",
+        "coc.nvim": "^0.0.80",
         "eslint": "^7.32.0",
-        "mocha": "^9.1.1",
         "merge-options": "^3.0.4",
-        "typescript": "^4.4.3"
-    },
-    "dependencies": {
-        "vscode-languageclient": "^7.0"
+        "mocha": "^9.1.1",
+        "ts-loader": "^9.5.1",
+        "typescript": "^4.4.3",
+        "webpack": "^5.96.1",
+        "webpack-cli": "^5.1.4"
     }
 }

--- a/coc-alex/scripts/patch.pl
+++ b/coc-alex/scripts/patch.pl
@@ -1,0 +1,2 @@
+#!/usr/bin/env -S perl -p
+s=//#==;

--- a/coc-alex/scripts/patch.sh
+++ b/coc-alex/scripts/patch.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$(dirname "$(readlink -f "$0")")")"
+
+for file; do
+  scripts/patch.pl "$file" | cpp -DHAVE_COC_NVIM -nostdinc -P -C -o"${file#*/*/}"
+done

--- a/coc-alex/src/.gitignore
+++ b/coc-alex/src/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/.gitignore

--- a/coc-alex/tsconfig.json
+++ b/coc-alex/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../client/tsconfig",
+    "compilerOptions": {
+        "outDir": "out",
+        "rootDir": "."
+    }
+}

--- a/coc-alex/webpack.config.js
+++ b/coc-alex/webpack.config.js
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../webpack.config');
+const path = require('path');
+
+module.exports = withDefaults({
+	context: path.join(__dirname),
+	entry: {
+		extension: './src/extension.ts',
+		server: './src/server.ts',
+	},
+	output: {
+		filename: '[name].js',
+		path: path.join(__dirname, 'out')
+	}
+});


### PR DESCRIPTION
![Screenshot_20250103_144548](https://github.com/user-attachments/assets/c2df283d-71aa-4ebe-b859-aa7715b5f127)

https://www.npmjs.com/package/coc-alex

Refer:
https://github.com/valentjn/vscode-ltex/blob/3d0cb8cd9b4d0dc8ef6c08a4f376767820678cf6/src/extension.ts#L8-L14

Difference is vscode-ltex/coc-ltex uses a customized python script
https://github.com/valentjn/vscode-ltex/blob/3d0cb8cd9b4d0dc8ef6c08a4f376767820678cf6/tools/patchForTarget.py
to patch code
we use c language macro preprocessor cpp


Can you add me to collaborators to maintain the support of coc.nvim?
And I want to add your npm account to collaborators of npm package of coc-alex due to
most code comes from you.
TIA!